### PR TITLE
Updating to support .net 4, 4.5, 4.6 and .net standard 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ _ReSharper*/
 *.*.user
 
 !tools/
+.vs/

--- a/MSBuild.SetEnvVariable.csproj
+++ b/MSBuild.SetEnvVariable.csproj
@@ -1,37 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{8A1C9A7F-4B99-49A9-92BE-495ECB61E500}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>MSBuild.SetEnvVariable</RootNamespace>
-    <AssemblyName>MSBuild.SetEnvVariable</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFrameworks>netstandard2.0;net40;net45;net46</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Authors></Authors>
+    <Company />
+    <Copyright>Copyright © 2011 Andrei Faber</Copyright>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net40' OR '$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46'">
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
@@ -42,16 +19,11 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="SetEnvVariable.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+       
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Build.Utilities.Core">
+      <Version>16.0.461</Version>
+    </PackageReference>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/MSBuild.SetEnvVariable.sln
+++ b/MSBuild.SetEnvVariable.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSBuild.SetEnvVariable", "MSBuild.SetEnvVariable.csproj", "{8A1C9A7F-4B99-49A9-92BE-495ECB61E500}"
 EndProject
 Global

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -5,13 +5,6 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("MSBuild.SetEnvVariable")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("MSBuild.SetEnvVariable")]
-[assembly: AssemblyCopyright("Copyright © 2011 Andrei Faber")]
-[assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
@@ -32,5 +25,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+

--- a/SetEnvVariable.cs
+++ b/SetEnvVariable.cs
@@ -8,36 +8,36 @@ using Microsoft.Build.Utilities;
 
 namespace MSBuild.SetEnvVariable
 {
-	public class SetEnvVariable : Task
-	{
-		private string _name;
-		private string _value;
+    public class SetEnvVariable : Task
+    {
+        private string _name;
+        private string _value;
 
-		[Required]
-		public string Name
-		{
-			get { return _name; }
-			set { _name = value; }
-		}
+        [Required]
+        public string Name
+        {
+            get { return _name; }
+            set { _name = value; }
+        }
 
-		public string Value
-		{
-			get { return _value; }
-			set { _value = value; }
-		}
+        public string Value
+        {
+            get { return _value; }
+            set { _value = value; }
+        }
 
-		public override bool Execute()
-		{
-			try
-			{
-				Environment.SetEnvironmentVariable(_name, _value);
-				return true;
-			}
-			catch (Exception exc)
-			{
-				Console.WriteLine(exc);
-				return false;
-			}
-		}
-	}
+        public override bool Execute()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(_name, _value);
+                return true;
+            }
+            catch (Exception exc)
+            {
+                Console.WriteLine(exc);
+                return false;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Here is a PR to allow this to build for .net 4.0, .net 4.5, .net 4.6 and .net standard 2.0 so that projects that depend on it won't give warnings about version mismatches